### PR TITLE
feat: use `/proc/self/cgroup` and `/proc/self/mountinfo` to retrieve the machine-id on Docker environments

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -44,3 +44,29 @@ func readFile(filename string) ([]byte, error) {
 func trim(s string) string {
 	return strings.TrimSpace(strings.Trim(s, "\n"))
 }
+
+type getIDFunction func() (string, error)
+
+func getIDFromFile(filePath string) getIDFunction {
+	return func() (string, error) {
+		bytes, err := readFile(filePath)
+		if err != nil {
+			return "", err
+		}
+
+		return string(bytes), nil
+	}
+}
+
+func getFirstValidValue(functions ...getIDFunction) (string, error) {
+	for _, fn := range functions {
+		id, err := fn()
+		if err != nil || id == "" {
+			continue
+		}
+
+		return id, nil
+	}
+
+	return "", errors.New("no machine-id found")
+}

--- a/helper.go
+++ b/helper.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"io/ioutil"
 	"os"
@@ -28,7 +29,16 @@ func protect(appID, id string) string {
 }
 
 func readFile(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filename)
+	bytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(bytes) == 0 {
+		return nil, errors.New("file is empty")
+	}
+
+	return bytes, nil
 }
 
 func trim(s string) string {

--- a/id_linux.go
+++ b/id_linux.go
@@ -13,8 +13,8 @@ const (
 	// on Docker, there are no files for machine-id, and installing
 	// dbus creates a static machine-id for all containers.
 	// To overcome this problem, we can add a last fallback value
-	// which is the hostname file, which, in Docker is the container
-	// name.
+	// which is the hostname file. In docker, the container name
+	// is defined as the hostname.
 	hostnamePath = "/etc/hostname"
 )
 


### PR DESCRIPTION
~At first I was going to use the `/proc/self/cgroup`, however, recent versions of Docker don't keep the container id there anymore and it would result in an empty string as well. The only alternative I found is using `/etc/hostname` instead.~

I also had to change the `readFile` helper function because on an Ubuntu container, the file `/etc/machine-id` exists, but it's empty. So I added a new condition that the file content must not be empty in order to be valid.

Edit: I changed the implementation as we talked and now it looks for `/proc/self/cgroup` and `/proc/self/mountinfo` , just like https://github.com/keygen-sh/py-machineid does.

**Alpine**
![image](https://github.com/user-attachments/assets/0c561b86-6dd8-4cf7-ae46-c7ccd1f841cc)



**Ubuntu**
![image](https://github.com/user-attachments/assets/67e54dd9-0a36-4f13-b344-4502fe915a8f)



