### PR TITLE
Fix failing unit test

### DIFF
--- a/cmd/machineid/main.go
+++ b/cmd/machineid/main.go
@@ -32,7 +32,7 @@ Try:
 `
 
 func usage() {
-	log.Fatalln(usageStr)
+	log.Fatal(usageStr)
 }
 
 func main() {


### PR DESCRIPTION
This fixes:
```
$ go test ./cmd/machineid/...
# github.com/keygen-sh/machineid/cmd/machineid
cmd/machineid/main.go:35:2: log.Fatalln arg list ends with redundant newline
FAIL	github.com/keygen-sh/machineid/cmd/machineid [build failed]
FAIL
```